### PR TITLE
Fix reloads

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -51,7 +51,7 @@ function addedUser(user) {
                 <label for="age">Age:</label>
                 <input type="number" min="0" max="100" name="age"  required />
 
-                <input type="submit" value="Submit" onclick = "submitUserClick(this)"/>
+                <input type="submit" value="Submit" onclick = "submitUserClick(this, event)"/>
                 <input type ="button" class="btn-cancel" value = "Cancel" onclick = "cancelUserClick(this)"/>
               </form>
             </div>
@@ -93,7 +93,8 @@ function cancelUserClick(target) {
   user_info.hidden = false;
 }
 
-function submitUserClick(target) {
+function submitUserClick(target, ev) {
+  ev.preventDefault();
   const parent_li = target.closest("li");
   const user_id = JSON.parse(parent_li.attributes["user-data"].value).id;
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "gulp": "^4.0.2"
   },
   "scripts": {
-    "devStart": "nodemon server.js"
+    "devStart": "nodemon --verbose --watch ./server.js server.js"
   },
   "devDependencies": {
     "nodemon": "^2.0.19"


### PR DESCRIPTION
1. Кнопке submit нужно делать preventDefault() иначе нажатие приведёт к отправке формы и соответственно - перезагрузке страницы.
2. В nodemon можно явно указать отслеживаемые файлы иначе сервер будет перезагружаться по изменению файлов, в данном случае по записи в users.json